### PR TITLE
Update nanoFramework.Runtime.Events dependency to 1.0.5-preview-010

### DIFF
--- a/source/Windows.Devices.SerialCommunication/Windows.Devices.SerialCommunication.nfproj
+++ b/source/Windows.Devices.SerialCommunication/Windows.Devices.SerialCommunication.nfproj
@@ -51,7 +51,7 @@
     <NFMDP_PE_LoadHints Include="..\packages\nanoFramework.Windows.Storage.Streams.1.0.5-preview-009\lib\Windows.Storage.Streams.dll">
       <InProject>false</InProject>
     </NFMDP_PE_LoadHints>
-    <NFMDP_PE_LoadHints Include="..\packages\nanoFramework.Runtime.Events.1.0.5-preview-008\lib\nanoFramework.Runtime.Events.dll">
+    <NFMDP_PE_LoadHints Include="..\packages\nanoFramework.Runtime.Events.1.0.5-preview-010\lib\nanoFramework.Runtime.Events.dll">
       <InProject>false</InProject>
     </NFMDP_PE_LoadHints>
   </ItemGroup>
@@ -86,7 +86,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Events, Version=1.0.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.Runtime.Events.1.0.5-preview-008\lib\nanoFramework.Runtime.Events.dll</HintPath>
+      <HintPath>..\packages\nanoFramework.Runtime.Events.1.0.5-preview-010\lib\nanoFramework.Runtime.Events.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Windows.Storage.Streams, Version=1.0.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">

--- a/source/Windows.Devices.SerialCommunication/packages.config
+++ b/source/Windows.Devices.SerialCommunication/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="nanoFramework.CoreLibrary" version="1.1.1" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Runtime.Events" version="1.0.5-preview-008" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Runtime.Events" version="1.0.5-preview-010" targetFramework="netnanoframework10" />
   <package id="nanoFramework.Windows.Storage.Streams" version="1.0.5-preview-009" targetFramework="netnanoframework10" />
   <package id="Nerdbank.GitVersioning" version="3.0.6-beta" developmentDependency="true" targetFramework="netnanoframework10" />
 </packages>

--- a/source/nanoFramework.Windows.Devices.SerialCommunication.DELIVERABLES.nuspec
+++ b/source/nanoFramework.Windows.Devices.SerialCommunication.DELIVERABLES.nuspec
@@ -20,7 +20,7 @@
     <dependencies>
       <dependency id="nanoFramework.CoreLibrary" version="[1.1.1]" />
       <dependency id="nanoFramework.Windows.Storage.Streams" version="[1.0.5-preview-009]" />
-      <dependency id="nanoFramework.Runtime.Events" version="[1.0.5-preview-008]" />
+      <dependency id="nanoFramework.Runtime.Events" version="[1.0.5-preview-010]" />
     </dependencies>
   </metadata>
   <files>

--- a/source/nanoFramework.Windows.Devices.SerialCommunication.nuspec
+++ b/source/nanoFramework.Windows.Devices.SerialCommunication.nuspec
@@ -19,7 +19,7 @@
     <dependencies>
       <dependency id="nanoFramework.CoreLibrary" version="[1.1.1]" />
       <dependency id="nanoFramework.Windows.Storage.Streams" version="[1.0.5-preview-009]" />
-      <dependency id="nanoFramework.Runtime.Events" version="[1.0.5-preview-008]" />
+      <dependency id="nanoFramework.Runtime.Events" version="[1.0.5-preview-010]" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
Bumps nanoFramework.Windows.Runtime.Events from 1.0.5-preview-008 to 1.0.5-preview-010.

[version update]
