### PR TITLE
Changes to add RS485 mode

### DIFF
--- a/Windows.Devices.SerialCommunication/Properties/AssemblyInfo.cs
+++ b/Windows.Devices.SerialCommunication/Properties/AssemblyInfo.cs
@@ -12,7 +12,7 @@ using System.Runtime.InteropServices;
 
 ////////////////////////////////////////////////////////////////
 // update this whenever the native assembly signature changes //
-[assembly: AssemblyNativeVersion("100.1.1.1")]
+[assembly: AssemblyNativeVersion("100.1.1.2")]
 ////////////////////////////////////////////////////////////////
 
 // Setting ComVisible to false makes the types in this assembly not visible 

--- a/Windows.Devices.SerialCommunication/SerialDevice.cs
+++ b/Windows.Devices.SerialCommunication/SerialDevice.cs
@@ -49,6 +49,7 @@ namespace Windows.Devices.SerialCommunication
         private SerialStopBitCount _stopBits = SerialStopBitCount.One;
         internal uint _bytesReceived;
         private char _watchChar;
+        private SerialMode _mode = SerialMode.Normal;
 
         private SerialDataReceivedEventHandler _callbacksDataReceivedEvent = null;
 
@@ -193,6 +194,22 @@ namespace Windows.Devices.SerialCommunication
             set
             {
                 _handshake = value;
+
+                // need to reconfigure device
+                NativeConfig();
+            }
+        }
+
+        public SerialMode Mode
+        {
+            get
+            {
+                return _mode;
+            }
+
+            set
+            {
+                _mode = value;
 
                 // need to reconfigure device
                 NativeConfig();

--- a/Windows.Devices.SerialCommunication/SerialMode.cs
+++ b/Windows.Devices.SerialCommunication/SerialMode.cs
@@ -1,0 +1,23 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+namespace Windows.Devices.SerialCommunication
+{
+	/// <summary>
+	/// Defines values for hardware and software mode of operation.
+	/// </summary>
+	public enum SerialMode
+	{
+		/// <summary>
+		/// Normal Serial mode with handshake define by SerialHandshake.
+		/// </summary>
+		Normal,
+		/// <summary>
+		/// Used for Half duplex RS485 mode. 
+		/// Puts the port in to half duplex RS485 mode where the RTS is raised while the port is sending data. Once data is completely sent the RTS signal is lowered.
+		/// </summary>
+		RS485
+	}
+}

--- a/Windows.Devices.SerialCommunication/Windows.Devices.SerialCommunication.nfproj
+++ b/Windows.Devices.SerialCommunication/Windows.Devices.SerialCommunication.nfproj
@@ -63,6 +63,7 @@
     <Compile Include="SerialDeviceOutputStream.cs" />
     <Compile Include="SerialError.cs" />
     <Compile Include="SerialHandshake.cs" />
+    <Compile Include="SerialMode.cs" />
     <Compile Include="SerialParity.cs" />
     <Compile Include="SerialPinChange.cs" />
     <Compile Include="SerialStopBitCount.cs" />


### PR DESCRIPTION
## Description
Add a mode property on the SerialDevice to allow the RS485 mode to be selected

Native change in ESP32 only

## Motivation and Context
- Resolves nanoframework/Home#673


## How Has This Been Tested?<!-- (if applicable) -->
See PR  https://github.com/nanoframework/nf-interpreter/pull/1826 for details

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
